### PR TITLE
[CW] [65309444] Fix Missing SessionID

### DIFF
--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -305,11 +305,11 @@
       };
 
       WH.prototype.getSessionID = function(currentTime) {
-        if ($.cookie(this.WH_SESSION_ID) === null) {
-          this.firstVisit = currentTime;
-          return currentTime;
-        } else {
+        if ($.cookie(this.WH_SESSION_ID) != null) {
           return $.cookie(this.WH_SESSION_ID);
+        } else {
+          this.firstVisit = currentTime;
+          return this.firstVisit;
         }
       };
 

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -305,8 +305,6 @@
       };
 
       WH.prototype.getSessionID = function(currentTime) {
-        var last_access_time;
-        last_access_time = $.cookie(this.WH_LAST_ACCESS_TIME) || currentTime;
         if ($.cookie(this.WH_SESSION_ID) === null) {
           this.firstVisit = currentTime;
           return currentTime;

--- a/spec/javascripts/AutotaggingSpec.js
+++ b/spec/javascripts/AutotaggingSpec.js
@@ -196,6 +196,37 @@ describe("Autotagging Suite", function() {
       });
     });
 
+    describe("#getSessionID", function() {
+
+      var time = 123;
+
+      beforeEach(function () {
+        $.cookie('WHSessionID','');
+      });
+
+      it('uses the cookie when present', function() {
+        $.cookie('WHSessionID',111222);
+        expect(wh.getSessionID(time)).toEqual('111222');
+      });
+
+      it('uses the time when cookie is null', function() {
+        spyOn($, 'cookie').andReturn(null);
+        expect(wh.getSessionID(time)).toEqual(time);
+      });
+
+      it('uses the time when cookie is undefined', function() {
+        spyOn($, 'cookie').andReturn(undefined);
+        expect(wh.getSessionID(time)).toEqual(time);
+      });
+
+      it('sets firstVisit to time when cookie is null', function() {
+        spyOn($, 'cookie').andReturn(null);
+        wh.getSessionID(time)
+        expect(wh.firstVisit).toEqual(time);
+      });
+
+    });
+
     it('#setOneTimeData records attributes', function() {
       once = {a: 'Apple', b: 'Banana'};
       wh.setOneTimeData(once);

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -234,7 +234,6 @@ define ['jquery', 'browserdetect', 'jquery.cookie',], ($, browserdetect) ->
       return
 
     getSessionID: (currentTime) ->
-      last_access_time = $.cookie(@WH_LAST_ACCESS_TIME) or currentTime
       if $.cookie(@WH_SESSION_ID) == null
         @firstVisit = currentTime
         return currentTime

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -234,11 +234,11 @@ define ['jquery', 'browserdetect', 'jquery.cookie',], ($, browserdetect) ->
       return
 
     getSessionID: (currentTime) ->
-      if $.cookie(@WH_SESSION_ID) == null
-        @firstVisit = currentTime
-        return currentTime
+      if $.cookie(@WH_SESSION_ID)?
+        $.cookie(@WH_SESSION_ID)
       else
-        return $.cookie(@WH_SESSION_ID)
+        @firstVisit = currentTime
+        @firstVisit
 
     setCookies: ->
       userID    = $.cookie(@WH_USER_ID)


### PR DESCRIPTION
When accessing a missing cookie in jquery.cookie (>= 1.4), the value is `undefined` instead of `null`. i.e. `$.cookie('foo')` used to return `null`, but now it returns `undefined`.
- Fixes a check for the session id in the cookie.
- Removed unused line for `last_access_time`

[Story](https://www.pivotaltracker.com/s/projects/296153/stories/65309444)
#### Checklist
- [x] Jasmine specs Pass
