### PR TITLE
Allows passing tag params to firePageViewTag

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "jquery.autotagging.js",
   "dependencies": {
     "jquery": ">=1.8.3 <2.0.0",

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -179,7 +179,7 @@
         obj.os = this.platform.OS;
         obj.browser = this.platform.browser;
         obj.ver = this.platform.version;
-        obj.ref = this.determineReferrer(document, window);
+        obj.ref = obj.ref || this.determineReferrer(document, window);
         obj.registration = $.cookie('sgn') === '1' ? 1 : 0;
         if ($.cookie('sgn') != null) {
           obj.person_id = $.cookie('zid');
@@ -242,10 +242,12 @@
         return ((now != null) && now.call(this.performance)) || new Date().getTime();
       };
 
-      WH.prototype.firePageViewTag = function() {
-        return this.fire({
-          type: 'pageview'
-        });
+      WH.prototype.firePageViewTag = function(options) {
+        if (options == null) {
+          options = {};
+        }
+        options.type = 'pageview';
+        return this.fire(options);
       };
 
       WH.prototype.getItemId = function(elem) {

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -131,7 +131,7 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       obj.os                      = @platform.OS
       obj.browser                 = @platform.browser
       obj.ver                     = @platform.version
-      obj.ref                     = @determineReferrer(document, window)
+      obj.ref                     = obj.ref || @determineReferrer(document, window)
       obj.registration            = if $.cookie('sgn') == '1' then 1 else 0
       obj.person_id               = $.cookie('zid') if $.cookie('sgn')?
 
@@ -184,8 +184,9 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
         @performance.mozNow
       (now? and now.call(@performance)) || new Date().getTime()
 
-    firePageViewTag: ->
-      @fire { type: 'pageview' }
+    firePageViewTag: (options = {}) ->
+      options.type = 'pageview'
+      @fire options
 
     getItemId: (elem) ->
       id = elem.attr('id')


### PR DESCRIPTION
Live update needs to pass a ref param to autotagging.  This just passes supplied options through to the fire function and sets the type as before.

It also makes fire set the ref option if one is passed.
