### PR TITLE
Lf 73070230 device recognition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 vendor/ruby
 vendor/javascripts
 .bundle
+node_modules

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 coffee: coffee -cwo . src
-jasmine: rake jasmine
+jasmine: bundle exec rake jasmine

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "1.0.40",
+  "version": "1.0.14",
   "main": "jquery.autotagging.js",
   "dependencies": {
     "jquery": ">=1.8.3 <2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "main": "jquery.autotagging.js",
   "dependencies": {
     "jquery": ">=1.8.3 <2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "lib",
     "spec",
     "src",
-    "vendor"
+    "vendor",
+    "guplfile.coffee"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "1.0.14",
+  "version": "1.0.33",
   "main": "jquery.autotagging.js",
   "dependencies": {
     "jquery": ">=1.8.3 <2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "1.0.33",
+  "version": "1.0.39",
   "main": "jquery.autotagging.js",
   "dependencies": {
     "jquery": ">=1.8.3 <2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "main": "jquery.autotagging.js",
   "dependencies": {
     "jquery": ">=1.8.3 <2.0.0",

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -14,7 +14,6 @@ paths =
   versionToCheck: 'bower.json'
   dest: './'
 
-@initials = ''
 inc = (importance, initials) ->
   gulp.src(paths.versionToBump)
     .pipe(bump(type: importance))
@@ -24,7 +23,7 @@ inc = (importance, initials) ->
     .pipe prompt.prompt({
       name: 'initials'
       type: 'input'
-      message: 'Enter Your Initials:'
+      message: 'Enter your initials:'
     }, (initials) -> @user = initials)
     .pipe(git.commit "[#{@user.initials}] [000000] Bump version" )
     .pipe(filter(paths.versionToCheck))

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -1,0 +1,38 @@
+gulp    = require 'gulp'
+
+p = require('./package.json')
+
+git    = require('gulp-git')
+bump   = require('gulp-bump')
+filter = require('gulp-filter')
+prompt = require('gulp-prompt')
+tag_version = require('gulp-tag-version')
+
+paths =
+  scripts: ['*.js']
+  versionToBump: ['./package.json', './bower.json']
+  versionToCheck: 'bower.json'
+  dest: './'
+
+promptOpts = [
+  {
+    type: 'input',
+    message: 'Enter Your Initials'
+  }
+]
+
+inc = (importance, initials) ->
+  gulp.src(paths.versionToBump)
+    .pipe(bump(type: importance))
+    .pipe(gulp.dest(paths.dest))
+    .pipe(prompt.prompt(promptOpts, (initials) -> @user_name = initials))
+    .pipe(git.commit("[#{@user_name}] [000000] Version Bump"))
+    .pipe(filter(paths.versionToCheck))
+    .pipe tag_version()
+    .pipe prompt.confirm promptOpts
+    .pipe(git.push('origin', 'master', { args: '--tags' }))
+
+gulp.task 'patch',   -> inc 'patch'
+gulp.task 'feature', -> inc 'minor'
+gulp.task 'release', -> inc 'major'
+

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -24,13 +24,18 @@ inc = (importance, initials) ->
       name: 'initials'
       type: 'input'
       message: 'Enter your initials:'
-    }, (initials) -> @user = initials)
+    }, (initials) ->
+    @user = initials
+    gulp.src(paths.versionToCheck)
+    .pipe(git.add())
     .pipe(git.commit "[#{@user.initials}] [000000] Bump version" )
     .pipe(filter(paths.versionToCheck))
     .pipe tag_version()
-    .pipe(git.push('origin', 'master', { args: '--tags' }))
+    .pipe(git.push('origin', git.revParse({args: '--abbrev-ref HEAD'}), { args: '--tags' }))
 
-gulp.task 'patch',   -> inc 'patch'
-gulp.task 'feature', -> inc 'minor'
-gulp.task 'release', -> inc 'major'
+    )
+# TODO: Waiting for revParse feature: https://github.com/stevelacy/gulp-git/pull/27/files
+# gulp.task 'patch',   -> inc 'patch'
+# gulp.task 'feature', -> inc 'minor'
+# gulp.task 'release', -> inc 'major'
 

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -14,22 +14,13 @@ paths =
   versionToCheck: 'bower.json'
   dest: './'
 
-promptOpts = [
-  {
-    type: 'input',
-    message: 'Enter Your Initials'
-  }
-]
-
 inc = (importance, initials) ->
   gulp.src(paths.versionToBump)
     .pipe(bump(type: importance))
     .pipe(gulp.dest(paths.dest))
-    .pipe(prompt.prompt(promptOpts, (initials) -> @user_name = initials))
-    .pipe(git.commit("[#{@user_name}] [000000] Version Bump"))
+    .pipe(git.commit('Version bump'))
     .pipe(filter(paths.versionToCheck))
     .pipe tag_version()
-    .pipe prompt.confirm promptOpts
     .pipe(git.push('origin', 'master', { args: '--tags' }))
 
 gulp.task 'patch',   -> inc 'patch'

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -14,11 +14,19 @@ paths =
   versionToCheck: 'bower.json'
   dest: './'
 
+@initials = ''
 inc = (importance, initials) ->
   gulp.src(paths.versionToBump)
     .pipe(bump(type: importance))
     .pipe(gulp.dest(paths.dest))
-    .pipe(git.commit('Version bump'))
+
+  gulp.src(paths.versionToCheck)
+    .pipe prompt.prompt({
+      name: 'initials'
+      type: 'input'
+      message: 'Enter Your Initials:'
+    }, (initials) -> @user = initials)
+    .pipe(git.commit "[#{@user.initials}] [000000] Bump version" )
     .pipe(filter(paths.versionToCheck))
     .pipe tag_version()
     .pipe(git.push('origin', 'master', { args: '--tags' }))

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -179,8 +179,8 @@
         return this.device || (this.device = this.desktopOrMobile());
       };
 
-      WH.prototype.desktopOrMobile = function() {
-        this.deviceWidth = $(window).width();
+      WH.prototype.desktopOrMobile = function(deviceWidth) {
+        this.deviceWidth = deviceWidth != null ? deviceWidth : $(window).width();
         if (this.desktop()) {
           return 'kilo';
         }

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -233,6 +233,9 @@
           obj.campaign_id = $.cookie('campaign_id');
         }
         obj.site_version = this.siteVersion;
+        if (obj.site_version != null) {
+          this.metaData.site_version = obj.site_version;
+        }
         if (obj.cg != null) {
           this.metaData.cg = obj.cg;
         }

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -11,6 +11,8 @@
   define(['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], function($, browserdetect, _) {
     var WH;
     return WH = (function() {
+      var DESKTOP_WIDTH, MOBILE_WIDTH;
+
       function WH() {
         this.obj2query = __bind(this.obj2query, this);
         this.firedTime = __bind(this.firedTime, this);
@@ -29,6 +31,10 @@
       WH.prototype.THIRTY_MINUTES_IN_MS = 30 * 60 * 1000;
 
       WH.prototype.TEN_YEARS_IN_DAYS = 3650;
+
+      MOBILE_WIDTH = 768;
+
+      DESKTOP_WIDTH = 1023;
 
       WH.prototype.cacheBuster = 0;
 
@@ -165,6 +171,39 @@
         return e.stopPropagation();
       };
 
+      WH.prototype.siteVersion = function() {
+        return "" + window.location.host + "_" + (this.deviceType());
+      };
+
+      WH.prototype.deviceType = function() {
+        return this.device || (this.device = this.desktopOrMobile());
+      };
+
+      WH.prototype.desktopOrMobile = function() {
+        this.deviceWidth = $(window).width();
+        if (this.desktop()) {
+          return 'kilo';
+        }
+        if (this.tablet()) {
+          return 'deca';
+        }
+        if (this.mobile()) {
+          return 'nano';
+        }
+      };
+
+      WH.prototype.desktop = function() {
+        return this.deviceWidth > DESKTOP_WIDTH;
+      };
+
+      WH.prototype.tablet = function() {
+        return this.deviceWidth >= MOBILE_WIDTH && this.deviceWidth <= DESKTOP_WIDTH;
+      };
+
+      WH.prototype.mobile = function() {
+        return this.deviceWidth < MOBILE_WIDTH;
+      };
+
       WH.prototype.fire = function(obj) {
         var key;
         obj.ft = this.firedTime();
@@ -187,6 +226,7 @@
         if ($.cookie('campaign_id') != null) {
           obj.campaign_id = $.cookie('campaign_id');
         }
+        obj.site_version = this.siteVersion();
         if (obj.cg != null) {
           this.metaData.cg = obj.cg;
         }

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -180,28 +180,29 @@
       };
 
       WH.prototype.desktopOrMobile = function(deviceWidth) {
-        this.deviceWidth = deviceWidth != null ? deviceWidth : $(window).width();
-        if (this.desktop()) {
-          return 'kilo';
+        if (deviceWidth == null) {
+          deviceWidth = $(window).width();
         }
-        if (this.tablet()) {
-          return 'deca';
-        }
-        if (this.mobile()) {
-          return 'nano';
+        switch (false) {
+          case !this.desktop(deviceWidth):
+            return 'kilo';
+          case !this.tablet(deviceWidth):
+            return 'deca';
+          case !this.mobile(deviceWidth):
+            return 'nano';
         }
       };
 
-      WH.prototype.desktop = function() {
-        return this.deviceWidth > DESKTOP_WIDTH;
+      WH.prototype.desktop = function(deviceWidth) {
+        return deviceWidth > DESKTOP_WIDTH;
       };
 
-      WH.prototype.tablet = function() {
-        return this.deviceWidth >= MOBILE_WIDTH && this.deviceWidth <= DESKTOP_WIDTH;
+      WH.prototype.tablet = function(deviceWidth) {
+        return deviceWidth >= MOBILE_WIDTH && deviceWidth <= DESKTOP_WIDTH;
       };
 
-      WH.prototype.mobile = function() {
-        return this.deviceWidth < MOBILE_WIDTH;
+      WH.prototype.mobile = function(deviceWidth) {
+        return deviceWidth < MOBILE_WIDTH;
       };
 
       WH.prototype.fire = function(obj) {

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -71,6 +71,7 @@
           this.clickBindSelector = this.clickBindSelector.replace(/,\s+/g, ":not(" + opts.exclusions + "), ");
         }
         this.domain = document.location.host;
+        this.setSiteVersion(opts);
         this.exclusionList = opts.exclusionList || [];
         this.fireCallback = opts.fireCallback;
         this.path = "" + document.location.pathname + document.location.search;
@@ -171,8 +172,12 @@
         return e.stopPropagation();
       };
 
-      WH.prototype.siteVersion = function() {
-        return "" + window.location.host + "_" + (this.deviceType());
+      WH.prototype.setSiteVersion = function(opts) {
+        if (opts.metaData) {
+          return this.siteVersion = "" + (opts.metaData.site_version || this.domain) + "_" + (this.deviceType());
+        } else {
+          return this.siteVersion = "" + this.domain + "_" + (this.deviceType());
+        }
       };
 
       WH.prototype.deviceType = function() {
@@ -227,7 +232,7 @@
         if ($.cookie('campaign_id') != null) {
           obj.campaign_id = $.cookie('campaign_id');
         }
-        obj.site_version = this.siteVersion();
+        obj.site_version = this.siteVersion;
         if (obj.cg != null) {
           this.metaData.cg = obj.cg;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "1.0.12",
+  "version": "1.0.14",
   "description": "Primedia autotagging plugin",
   "homepage": "https://github.com/primedia/preserves",
   "author": "RentPath",
@@ -9,11 +9,7 @@
     "type": "git",
     "url": "https://github.com/primedia/preserves.git"
   },
-  "bugs": {
-    "url": "https://github.com/primedia/preserves/issues"
-  },
   "devDependencies": {
-    "coffee-script": "^1.7.1",
     "gulp": "^3.8.6",
     "gulp-bump": "^0.1.10",
     "gulp-filter": "^0.5.0",
@@ -23,7 +19,7 @@
   },
   "main": "jquery.autotagging.js",
   "scripts": {
-    "test":  "bundle exec rake jasmine",
+    "test": "bundle exec rake jasmine",
     "start": "foreman start"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,32 +3,27 @@
   "version": "1.0.12",
   "description": "Primedia autotagging plugin",
   "homepage": "https://github.com/primedia/preserves",
-
-  "jam": {
-    "packageDir": "vendor/jam",
-    "baseUrl": ".",
-    "dependencies": {
-      "jquery": "1.8.3-rjs",
-      "jquery.cookie": "1.4.0",
-      "browserdetect": null,
-      "underscore": null
-    },
-    "main": "jquery.autotagging.js",
-    "include": [
-      "jquery.autotagging.js"
-    ]
+  "author": "RentPath",
+  "github": "https://github.com/primedia/jquery-autotagging.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/primedia/preserves.git"
   },
-
-  "author": {
-    "name": "Primedia"
+  "bugs": {
+    "url": "https://github.com/primedia/preserves/issues"
   },
-
-  "repositories": [
-    {
-        "type": "git",
-        "url": "https://github.com/primedia/preserves.git"
-    }
-  ],
-
-  "github": "https://github.com/primedia/preserves.git"
+  "devDependencies": {
+    "coffee-script": "^1.7.1",
+    "gulp": "^3.8.6",
+    "gulp-bump": "^0.1.10",
+    "gulp-filter": "^0.5.0",
+    "gulp-git": "^0.4.3",
+    "gulp-prompt": "^0.1.1",
+    "gulp-tag-version": "^1.0.2"
+  },
+  "main": "jquery.autotagging.js",
+  "scripts": {
+    "test":  "bundle exec rake jasmine",
+    "start": "foreman start"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Primedia autotagging plugin",
   "homepage": "https://github.com/primedia/preserves",
   "author": "RentPath",

--- a/spec/javascripts/AutotaggingSpec.js
+++ b/spec/javascripts/AutotaggingSpec.js
@@ -318,6 +318,24 @@ describe("Autotagging Suite", function() {
       });
     });
 
+    describe("#desktopOrMobile", function() {
+      it('recognizes desktop', function() {
+        expect(wh.desktopOrMobile(1025)).toEqual('kilo');
+      });
+      it('recognizes tablets', function() {
+        expect(wh.desktopOrMobile(768)).toEqual('deca');
+      });
+     it('recognizes mobile', function() {
+        expect(wh.desktopOrMobile(767)).toEqual('nano');
+      });
+
+
+      it('overrides default with argument', function() {
+        wh.setFollowHref({followHref:false});
+        expect(wh.followHref).toEqual(false);
+      });
+    });
+
     describe("#determineReferrer", function() {
       beforeEach(function() {
         testDocument = $('<div></div>');

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -158,6 +158,7 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       obj.person_id               = $.cookie('zid') if $.cookie('sgn')?
       obj.campaign_id             = $.cookie('campaign_id') if $.cookie('campaign_id')?
       obj.site_version            = @siteVersion
+      @metaData.site_version = obj.site_version if obj.site_version?
       @metaData.cg = obj.cg if obj.cg?
       @metaData.cg = '' if !@metaData.cg?
 
@@ -196,7 +197,8 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
 
           @warehouseTag.unbind('load').unbind('error').
             bind('load',  lastLinkRedirect).
-            bind('error', lastLinkRedirect))
+            bind('error', lastLinkRedirect)
+      )
 
     firedTime: =>
       now =

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -8,6 +8,9 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
     WH_USER_ID: 'WHUserID'
     THIRTY_MINUTES_IN_MS: 30 * 60 * 1000
     TEN_YEARS_IN_DAYS: 3650
+    MOBILE_WIDTH  = 768
+    DESKTOP_WIDTH = 1023
+
     cacheBuster:  0
     domain:       ''
     firstVisit:   null
@@ -118,6 +121,21 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       @fire trackingData
       e.stopPropagation()
 
+    siteVersion: ->
+      "#{window.location.host}_#{@deviceType()}"
+
+    deviceType: -> @device ||= @desktopOrMobile()
+
+    desktopOrMobile: ->
+      @deviceWidth  = $(window).width()
+      return 'kilo' if @desktop()
+      return 'deca' if @tablet()
+      return 'nano' if @mobile()
+
+    desktop: -> @deviceWidth >  DESKTOP_WIDTH
+    tablet:  -> @deviceWidth >= MOBILE_WIDTH and @deviceWidth <= DESKTOP_WIDTH
+    mobile:  -> @deviceWidth <  MOBILE_WIDTH
+
     fire: (obj) =>
       obj.ft                      = @firedTime()
       obj.cb                      = @cacheBuster++
@@ -135,6 +153,7 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       obj.registration            = if $.cookie('sgn') == '1' then 1 else 0
       obj.person_id               = $.cookie('zid') if $.cookie('sgn')?
       obj.campaign_id             = $.cookie('campaign_id') if $.cookie('campaign_id')?
+      obj.site_version            = @siteVersion()
 
       @metaData.cg = obj.cg if obj.cg?
       @metaData.cg = '' if !@metaData.cg?
@@ -210,8 +229,7 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
           retObj[name] = metaTag.attr('content')
       retObj
 
-    getOneTimeData: ->
-      @oneTimeData
+    getOneTimeData: -> @oneTimeData
 
     # we are putting the tags ina predefined order before firing.  This will have
     # a performance hit - mocked in jsfiddle

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -27,12 +27,13 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       174: '(r)'
     }
 
+
     init: (opts={}) =>
       @clickBindSelector = opts.clickBindSelector || 'a, input[type=submit], input[type=button], img'
       if opts.exclusions?
         @clickBindSelector = @clickBindSelector.replace(/,\s+/g, ":not(#{opts.exclusions}), ")
-
       @domain            = document.location.host
+      @setSiteVersion(opts)
       @exclusionList     = opts.exclusionList || []
       @fireCallback      = opts.fireCallback
       @path              = "#{document.location.pathname}#{document.location.search}"
@@ -121,7 +122,11 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       @fire trackingData
       e.stopPropagation()
 
-    siteVersion: -> "#{window.location.host}_#{@deviceType()}"
+    setSiteVersion: (opts) ->
+      if opts.metaData
+        @siteVersion     = "#{opts.metaData.site_version || @domain}_#{@deviceType()}"
+      else
+        @siteVersion     = "#{@domain}_#{@deviceType()}"
 
     deviceType: -> @device ||= @desktopOrMobile()
 
@@ -152,7 +157,7 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       obj.registration            = if $.cookie('sgn') == '1' then 1 else 0
       obj.person_id               = $.cookie('zid') if $.cookie('sgn')?
       obj.campaign_id             = $.cookie('campaign_id') if $.cookie('campaign_id')?
-      obj.site_version            = @siteVersion()
+      obj.site_version            = @siteVersion
       @metaData.cg = obj.cg if obj.cg?
       @metaData.cg = '' if !@metaData.cg?
 

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -121,19 +121,19 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       @fire trackingData
       e.stopPropagation()
 
-    siteVersion: ->
-      "#{window.location.host}_#{@deviceType()}"
+    siteVersion: -> "#{window.location.host}_#{@deviceType()}"
 
     deviceType: -> @device ||= @desktopOrMobile()
 
-    desktopOrMobile: (@deviceWidth = $(window).width()) ->
-      return 'kilo' if @desktop()
-      return 'deca' if @tablet()
-      return 'nano' if @mobile()
+    desktopOrMobile: (deviceWidth = $(window).width()) ->
+      switch
+        when @desktop(deviceWidth) then 'kilo'
+        when @tablet(deviceWidth)  then 'deca'
+        when @mobile(deviceWidth)  then 'nano'
 
-    desktop: -> @deviceWidth >  DESKTOP_WIDTH
-    tablet:  -> @deviceWidth >= MOBILE_WIDTH and @deviceWidth <= DESKTOP_WIDTH
-    mobile:  -> @deviceWidth <  MOBILE_WIDTH
+    desktop: (deviceWidth) -> deviceWidth >  DESKTOP_WIDTH
+    tablet:  (deviceWidth) -> deviceWidth >= MOBILE_WIDTH and deviceWidth <= DESKTOP_WIDTH
+    mobile:  (deviceWidth) -> deviceWidth <  MOBILE_WIDTH
 
     fire: (obj) =>
       obj.ft                      = @firedTime()
@@ -153,7 +153,6 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
       obj.person_id               = $.cookie('zid') if $.cookie('sgn')?
       obj.campaign_id             = $.cookie('campaign_id') if $.cookie('campaign_id')?
       obj.site_version            = @siteVersion()
-
       @metaData.cg = obj.cg if obj.cg?
       @metaData.cg = '' if !@metaData.cg?
 

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -126,8 +126,7 @@ define ['jquery', 'browserdetect', 'underscore', 'jquery.cookie'], ($, browserde
 
     deviceType: -> @device ||= @desktopOrMobile()
 
-    desktopOrMobile: ->
-      @deviceWidth  = $(window).width()
+    desktopOrMobile: (@deviceWidth = $(window).width()) ->
       return 'kilo' if @desktop()
       return 'deca' if @tablet()
       return 'nano' if @mobile()


### PR DESCRIPTION
# [Support for device recognition](https://www.pivotaltracker.com/story/show/73070230)
- Allows `site_version` to be generated via autotagging library 
  - `site_version` changes based on device width
  - Retain backwards compatibility for `ag_sites` which does not rely on `window.location` to populate site_version. 
  - Specs added & passing
- Add release task via gulp. The work here is incomplete atm, waiting on a new NPM build for gulp git pkg
# Related PRs

---
- https://github.com/primedia/ag/pull/1663
- https://github.com/primedia/m.newhomeguide/pull/281
- https://github.com/primedia/ag_sites/pull/112
