### PR TITLE
[CW] [78552498] Fix Load and Error Event Triggers

### DIFF
--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -10,6 +10,7 @@
       function WH() {
         this.obj2query = __bind(this.obj2query, this);
         this.firedTime = __bind(this.firedTime, this);
+        this.shouldRedirectToLastLinkClicked = __bind(this.shouldRedirectToLastLinkClicked, this);
         this.fire = __bind(this.fire, this);
         this.elemClicked = __bind(this.elemClicked, this);
         this.clearOneTimeData = __bind(this.clearOneTimeData, this);
@@ -231,19 +232,18 @@
               return $element.trigger('WH_pixel_error_' + obj.type);
             });
             _this.warehouseTag[0].src = requestURL;
-            if (_this.lastLinkClicked != null) {
+            if (_this.shouldRedirectToLastLinkClicked()) {
               lastLinkRedirect = function(e) {
-                if (!((_this.lastLinkClicked != null) && (_this.lastLinkClicked.indexOf != null))) {
-                  return;
-                }
-                if (_this.lastLinkClicked.indexOf('javascript:') === -1) {
-                  return document.location = _this.lastLinkClicked;
-                }
+                return document.location = _this.lastLinkClicked;
               };
               return _this.warehouseTag.unbind('load').unbind('error').bind('load', lastLinkRedirect).bind('error', lastLinkRedirect);
             }
           };
         })(this));
+      };
+
+      WH.prototype.shouldRedirectToLastLinkClicked = function() {
+        return (this.lastLinkClicked != null) && (this.lastLinkClicked.indexOf != null) && this.lastLinkClicked.indexOf('javascript:') === -1;
       };
 
       WH.prototype.firedTime = function() {

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -224,10 +224,10 @@
               });
             }
             $element = $element || $('body');
-            _this.warehouseTag.load(function() {
+            _this.warehouseTag.unbind('load').load(function() {
               return $element.trigger('WH_pixel_success_' + obj.type);
             });
-            _this.warehouseTag.error(function() {
+            _this.warehouseTag.unbind('error').error(function() {
               return $element.trigger('WH_pixel_error_' + obj.type);
             });
             _this.warehouseTag[0].src = requestURL;

--- a/spec/javascripts/AutotaggingSpec.js
+++ b/spec/javascripts/AutotaggingSpec.js
@@ -111,6 +111,23 @@ describe("Autotagging Suite", function() {
       });
     });
 
+    describe('#shouldRedirectToLastLinkClicked', function () {
+      it('should when present', function () {
+        wh.lastLinkClicked = '/';
+        expect(wh.shouldRedirectToLastLinkClicked()).toEqual(true);
+      });
+
+      it('should not when null', function () {
+        wh.lastLinkClicked = null;
+        expect(wh.shouldRedirectToLastLinkClicked()).toEqual(false);
+      });
+
+      it('should not when javascript:', function () {
+        wh.lastLinkClicked = 'javascript: void(0);';
+        expect(wh.shouldRedirectToLastLinkClicked()).toEqual(false);
+      });
+    });
+
     describe('#firstClass', function() {
       it('yields the first class name of the element', function() {
         testElement = $("<div class='first second third'></div>");

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -150,10 +150,17 @@ define [
             {id:'PRMWarehouseTag', border:'0', width:'1', height:'1'})
 
         $element = $element || $('body')
-        @warehouseTag.load ->
-          $element.trigger('WH_pixel_success_' + obj.type)
-        @warehouseTag.error ->
-          $element.trigger('WH_pixel_error_' + obj.type)
+
+        # NOTE: Binding to 'load' has several caveats: http://api.jquery.com/load-event/
+        @warehouseTag
+          .unbind('load')
+          .load ->
+            $element.trigger('WH_pixel_success_' + obj.type)
+
+        @warehouseTag
+          .unbind('error')
+          .error ->
+            $element.trigger('WH_pixel_error_' + obj.type)
 
         # The request for the tracking pixel happens here.
         @warehouseTag[0].src = requestURL

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -165,16 +165,22 @@ define [
         # The request for the tracking pixel happens here.
         @warehouseTag[0].src = requestURL
 
-        if @lastLinkClicked?
+        if @shouldRedirectToLastLinkClicked()
           lastLinkRedirect = (e) =>
-            return unless @lastLinkClicked? && @lastLinkClicked.indexOf?
-            # ignore obtrusive JS in an href attribute
-            document.location = @lastLinkClicked if @lastLinkClicked.indexOf('javascript:') == -1
+            document.location = @lastLinkClicked
 
-          @warehouseTag.unbind('load').unbind('error').
-            bind('load',  lastLinkRedirect).
-            bind('error', lastLinkRedirect)
+          @warehouseTag
+            .unbind('load')
+            .unbind('error')
+            .bind('load',  lastLinkRedirect)
+            .bind('error', lastLinkRedirect)
       )
+
+    shouldRedirectToLastLinkClicked: =>
+      @lastLinkClicked? &&
+      @lastLinkClicked.indexOf? &&
+      # ignore obtrusive JS in an href attribute
+      @lastLinkClicked.indexOf('javascript:') == -1
 
     firedTime: =>
       now =


### PR DESCRIPTION
**Prevent Double Binding on Load and Error**
- Unbind previous load and error event listeners on the pixel.

Previously, load and error events were triggered multiple times when the pixel fires.

**Prevent Unintentional Unbinding of Load Event Listener**
- Links with 'javascript: void(0)' (e.g. the check avail button) no longer unbind the load and error events.

[Story](https://www.pivotaltracker.com/story/show/78552498)
- [x] Specs and IE8 Pass
