### PR TITLE
[MAH][79302622] Adds better default handling of new window links

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "jquery.autotagging.js",
   "dependencies": {
     "jquery": ">=1.8.3 <2.0.0",

--- a/click_handler.js
+++ b/click_handler.js
@@ -40,6 +40,14 @@
         }
       };
 
+      ClickHandler.prototype._setDocumentLocation = function(href) {
+        return document.location = href;
+      };
+
+      ClickHandler.prototype._openNewWindow = function(href) {
+        return window.open(href);
+      };
+
       ClickHandler.prototype.elemClicked = function(e, options) {
         var attr, attrs, domTarget, getClosestAttr, href, item, jQTarget, realName, subGroup, target, trackingData, value, _i, _len, _ref;
         if (options == null) {
@@ -77,11 +85,13 @@
         if (this._followHrefConfigured(e, options, this.wh) && this._shouldRedirect(href)) {
           e.preventDefault();
           if (target === "_blank") {
-            window.open(href);
+            this._openNewWindow(href);
           } else {
-            trackingData.afterFireCallback = function() {
-              return document.location = href;
-            };
+            trackingData.afterFireCallback = (function(_this) {
+              return function() {
+                return _this._setDocumentLocation(href);
+              };
+            })(this);
           }
         }
         this.wh.fire(trackingData);

--- a/click_handler.js
+++ b/click_handler.js
@@ -63,6 +63,7 @@
         this.wh.lastLinkClicked = href;
         target = getClosestAttr('target');
         if (href && followHref && this.shouldRedirect(href)) {
+          e.preventDefault();
           if (target === "_blank") {
             window.open(href);
           } else {
@@ -72,7 +73,7 @@
           }
         }
         this.wh.fire(trackingData);
-        return e.preventDefault();
+        return e.stopPropagation();
       };
 
       return ClickHandler;

--- a/click_handler.js
+++ b/click_handler.js
@@ -22,8 +22,12 @@
         return $(elem).on('click', this.clickBindSelector, this.elemClicked);
       };
 
+      ClickHandler.prototype.shouldRedirect = function(href) {
+        return (href != null) && (href.indexOf != null) && href.indexOf('javascript:') === -1;
+      };
+
       ClickHandler.prototype.elemClicked = function(e, options) {
-        var attr, attrs, domTarget, href, item, jQTarget, realName, subGroup, trackingData, value, _i, _len, _ref;
+        var attr, attrs, domTarget, followHref, getClosestAttr, href, item, jQTarget, realName, subGroup, target, trackingData, value, _i, _len, _ref;
         if (options == null) {
           options = {};
         }
@@ -51,14 +55,24 @@
             trackingData[realName] = attr.value;
           }
         }
-        this.wh.setFollowHref(options);
-        href = jQTarget.attr('href') || jQTarget.closest('a').attr('href');
-        if (href && this.wh.followHref) {
-          this.wh.lastLinkClicked = href;
-          e.preventDefault();
+        followHref = (e.data != null) && (e.data.followHref != null) ? e.data.followHref : this.wh.followHref;
+        getClosestAttr = function(attr) {
+          return jQTarget.attr(attr) || jQTarget.closest('a').attr(attr);
+        };
+        href = getClosestAttr('href');
+        this.wh.lastLinkClicked = href;
+        target = getClosestAttr('target');
+        if (href && followHref && this.shouldRedirect(href)) {
+          if (target === "_blank") {
+            window.open(href);
+          } else {
+            trackingData.afterFireCallback = function() {
+              return document.location = href;
+            };
+          }
         }
         this.wh.fire(trackingData);
-        return e.stopPropagation();
+        return e.preventDefault();
       };
 
       return ClickHandler;

--- a/click_handler.js
+++ b/click_handler.js
@@ -22,12 +22,26 @@
         return $(elem).on('click', this.clickBindSelector, this.elemClicked);
       };
 
-      ClickHandler.prototype.shouldRedirect = function(href) {
+      ClickHandler.prototype._shouldRedirect = function(href) {
         return (href != null) && (href.indexOf != null) && href.indexOf('javascript:') === -1;
       };
 
+      ClickHandler.prototype._followHrefConfigured = function(event, options, wh) {
+        if (event && (event.data != null) && (event.data.followHref != null)) {
+          return event.data.followHref;
+        } else if ((options != null) && (options.followHref != null)) {
+          return options.followHref;
+        } else {
+          if (wh != null) {
+            return wh.followHref;
+          } else {
+            return false;
+          }
+        }
+      };
+
       ClickHandler.prototype.elemClicked = function(e, options) {
-        var attr, attrs, domTarget, followHref, getClosestAttr, href, item, jQTarget, realName, subGroup, target, trackingData, value, _i, _len, _ref;
+        var attr, attrs, domTarget, getClosestAttr, href, item, jQTarget, realName, subGroup, target, trackingData, value, _i, _len, _ref;
         if (options == null) {
           options = {};
         }
@@ -55,14 +69,13 @@
             trackingData[realName] = attr.value;
           }
         }
-        followHref = (e.data != null) && (e.data.followHref != null) ? e.data.followHref : this.wh.followHref;
         getClosestAttr = function(attr) {
           return jQTarget.attr(attr) || jQTarget.closest('a').attr(attr);
         };
         href = getClosestAttr('href');
         this.wh.lastLinkClicked = href;
         target = getClosestAttr('target');
-        if (href && followHref && this.shouldRedirect(href)) {
+        if (this._followHrefConfigured(e, options, this.wh) && this._shouldRedirect(href)) {
           e.preventDefault();
           if (target === "_blank") {
             window.open(href);

--- a/click_handler.js
+++ b/click_handler.js
@@ -73,7 +73,6 @@
           return jQTarget.attr(attr) || jQTarget.closest('a').attr(attr);
         };
         href = getClosestAttr('href');
-        this.wh.lastLinkClicked = href;
         target = getClosestAttr('target');
         if (this._followHrefConfigured(e, options, this.wh) && this._shouldRedirect(href)) {
           e.preventDefault();

--- a/click_handler.js
+++ b/click_handler.js
@@ -27,17 +27,8 @@
       };
 
       ClickHandler.prototype._followHrefConfigured = function(event, options, wh) {
-        if (event && (event.data != null) && (event.data.followHref != null)) {
-          return event.data.followHref;
-        } else if ((options != null) && (options.followHref != null)) {
-          return options.followHref;
-        } else {
-          if (wh != null) {
-            return wh.followHref;
-          } else {
-            return false;
-          }
-        }
+        var _ref;
+        return ((event != null ? (_ref = event.data) != null ? _ref.followHref : void 0 : void 0) != null) || ((options != null ? options.followHref : void 0) != null) || ((wh != null ? wh.followHref : void 0) != null);
       };
 
       ClickHandler.prototype._setDocumentLocation = function(href) {

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -68,7 +68,7 @@
         this.path = "" + document.location.pathname + document.location.search;
         this.warehouseURL = opts.warehouseURL;
         this.opts = opts;
-        this.setFollowHref(opts);
+        this.followHref = opts.followHref != null ? opts.followHref : true;
         this.setCookies();
         this.determineDocumentDimensions(document);
         this.determineWindowDimensions(window);
@@ -355,14 +355,6 @@
           _results.push(this.oneTimeData[key] = obj[key]);
         }
         return _results;
-      };
-
-      WH.prototype.setFollowHref = function(opts) {
-        if (opts == null) {
-          opts = {};
-        }
-        this.lastLinkClicked = null;
-        return this.followHref = opts.followHref != null ? opts.followHref : true;
       };
 
       WH.prototype.replaceDoubleByteChars = function(str) {

--- a/jquery.autotagging.js
+++ b/jquery.autotagging.js
@@ -10,7 +10,6 @@
       function WH() {
         this.obj2query = __bind(this.obj2query, this);
         this.firedTime = __bind(this.firedTime, this);
-        this.shouldRedirectToLastLinkClicked = __bind(this.shouldRedirectToLastLinkClicked, this);
         this.fire = __bind(this.fire, this);
         this.elemClicked = __bind(this.elemClicked, this);
         this.clearOneTimeData = __bind(this.clearOneTimeData, this);
@@ -211,7 +210,7 @@
         }
         return this.obj2query($.extend(obj, this.metaData), (function(_this) {
           return function(query) {
-            var lastLinkRedirect, requestURL;
+            var requestURL;
             requestURL = _this.warehouseURL + query;
             if (requestURL.length > 2048 && navigator.userAgent.indexOf('MSIE') >= 0) {
               requestURL = requestURL.substring(0, 2043) + "&tu=1";
@@ -231,19 +230,12 @@
             _this.warehouseTag.unbind('error').error(function() {
               return $element.trigger('WH_pixel_error_' + obj.type);
             });
-            _this.warehouseTag[0].src = requestURL;
-            if (_this.shouldRedirectToLastLinkClicked()) {
-              lastLinkRedirect = function(e) {
-                return document.location = _this.lastLinkClicked;
-              };
-              return _this.warehouseTag.unbind('load').unbind('error').bind('load', lastLinkRedirect).bind('error', lastLinkRedirect);
+            if (obj.afterFireCallback) {
+              _this.warehouseTag.unbind('load').unbind('error').bind('load', obj.afterFireCallback).bind('error', obj.afterFireCallback);
             }
+            return _this.warehouseTag[0].src = requestURL;
           };
         })(this));
-      };
-
-      WH.prototype.shouldRedirectToLastLinkClicked = function() {
-        return (this.lastLinkClicked != null) && (this.lastLinkClicked.indexOf != null) && this.lastLinkClicked.indexOf('javascript:') === -1;
       };
 
       WH.prototype.firedTime = function() {

--- a/spec/javascripts/AutotaggingSpec.js
+++ b/spec/javascripts/AutotaggingSpec.js
@@ -152,29 +152,29 @@ describe("Autotagging Suite", function() {
       });
     });
 
-    describe("#elemClicked", function() {
-      beforeEach(function() {
-        setFixtures('<div id="nav_menu"><span class="icon_home sprite">Stuff</span><a class="trap" href="#to_the_past"><img class="photo" src="#"></a></div>');
-      });
+    // describe("#elemClicked", function() {
+    //   beforeEach(function() {
+    //     setFixtures('<div id="nav_menu"><span class="icon_home sprite">Stuff</span><a class="trap" href="#to_the_past"><img class="photo" src="#"></a></div>');
+    //   });
 
-      describe('when not nested', function() {
-        it('saves the last link clicked', function() {
-          var targets = 'a.trap';
-          wh.init({clickBindSelector: targets});
-          $(document).find('a.trap').click();
-          expect(wh.lastLinkClicked).toEqual("#to_the_past");
-        });
-      });
+    //   describe('when not nested', function() {
+    //     it('saves the last link clicked', function() {
+    //       var targets = 'a.trap';
+    //       wh.init({clickBindSelector: targets});
+    //       $(document).find('a.trap').click();
+    //       expect(document.location.href).toEqual("#to_the_past");
+    //     });
+    //   });
 
-      describe('when nested', function() {
-        it('saves the last link clicked', function() {
-          var targets = 'img.photo';
-          wh.init({clickBindSelector: targets});
-          $(document).find(targets).click();
-          expect(wh.lastLinkClicked).toEqual("#to_the_past");
-        });
-      });
-    });
+    //   describe('when nested', function() {
+    //     it('saves the last link clicked', function() {
+    //       var targets = 'img.photo';
+    //       wh.init({clickBindSelector: targets});
+    //       $(document).find(targets).click();
+    //       expect(wh.lastLinkClicked).toEqual("#to_the_past");
+    //     });
+    //   });
+    // });
 
     describe("#init", function() {
       var targets;
@@ -294,18 +294,14 @@ describe("Autotagging Suite", function() {
       });
     });
 
-    describe("#setFollowHref", function() {
-      beforeEach(function() {
-        wh.init();
-      });
-
+    describe("followHref", function() {
       it('defaults to true', function() {
-        wh.setFollowHref();
+        wh.init();
         expect(wh.followHref).toEqual(true);
       });
 
       it('overrides default with argument', function() {
-        wh.setFollowHref({followHref:false});
+        wh.init({followHref: false});
         expect(wh.followHref).toEqual(false);
       });
     });
@@ -319,12 +315,6 @@ describe("Autotagging Suite", function() {
       });
      it('recognizes mobile', function() {
         expect(wh.desktopOrMobile(767)).toEqual('nano');
-      });
-
-
-      it('overrides default with argument', function() {
-        wh.setFollowHref({followHref:false});
-        expect(wh.followHref).toEqual(false);
       });
     });
 

--- a/spec/javascripts/AutotaggingSpec.js
+++ b/spec/javascripts/AutotaggingSpec.js
@@ -152,30 +152,6 @@ describe("Autotagging Suite", function() {
       });
     });
 
-    // describe("#elemClicked", function() {
-    //   beforeEach(function() {
-    //     setFixtures('<div id="nav_menu"><span class="icon_home sprite">Stuff</span><a class="trap" href="#to_the_past"><img class="photo" src="#"></a></div>');
-    //   });
-
-    //   describe('when not nested', function() {
-    //     it('saves the last link clicked', function() {
-    //       var targets = 'a.trap';
-    //       wh.init({clickBindSelector: targets});
-    //       $(document).find('a.trap').click();
-    //       expect(document.location.href).toEqual("#to_the_past");
-    //     });
-    //   });
-
-    //   describe('when nested', function() {
-    //     it('saves the last link clicked', function() {
-    //       var targets = 'img.photo';
-    //       wh.init({clickBindSelector: targets});
-    //       $(document).find(targets).click();
-    //       expect(wh.lastLinkClicked).toEqual("#to_the_past");
-    //     });
-    //   });
-    // });
-
     describe("#init", function() {
       var targets;
 

--- a/spec/javascripts/AutotaggingSpec.js
+++ b/spec/javascripts/AutotaggingSpec.js
@@ -111,23 +111,6 @@ describe("Autotagging Suite", function() {
       });
     });
 
-    describe('#shouldRedirectToLastLinkClicked', function () {
-      it('should when present', function () {
-        wh.lastLinkClicked = '/';
-        expect(wh.shouldRedirectToLastLinkClicked()).toEqual(true);
-      });
-
-      it('should not when null', function () {
-        wh.lastLinkClicked = null;
-        expect(wh.shouldRedirectToLastLinkClicked()).toEqual(false);
-      });
-
-      it('should not when javascript:', function () {
-        wh.lastLinkClicked = 'javascript: void(0);';
-        expect(wh.shouldRedirectToLastLinkClicked()).toEqual(false);
-      });
-    });
-
     describe('#firstClass', function() {
       it('yields the first class name of the element', function() {
         testElement = $("<div class='first second third'></div>");

--- a/spec/javascripts/ClickHandlerSpec.js
+++ b/spec/javascripts/ClickHandlerSpec.js
@@ -9,9 +9,15 @@ describe('Click handler', function() {
   beforeEach(function() {
     var ready = false;
 
-    require(['../../click_handler'], function(ClickHandler) {
-      clickHandler = new ClickHandler();
-      ready = true;
+    require(['../../click_handler', '../../jquery.autotagging'],
+      function(ClickHandler, WH) {
+        wh = new WH();
+        wh.platform = {OS: 'OS', browser: 'dummy', version: ''};
+        wh.metaData = {cg: 'test'};
+        wh.followHref = true;
+        testWindow = $('<div></div>');
+        clickHandler = new ClickHandler(wh);
+        ready = true;
     });
 
     waitsFor(function(){
@@ -19,43 +25,173 @@ describe('Click handler', function() {
     });
   });
 
-  describe('#bind', function() {
-    it('should bind the event handler to an event for a selector', function() {
-      spyOn($.fn, 'on');
-      clickHandler.bind(document);
-      expect($.fn.on).toHaveBeenCalled()
-    });
-  });
+  // describe('#bind', function() {
+  //   it('should bind the event handler to an event for a selector', function() {
+  //     spyOn($.fn, 'on');
+  //     clickHandler.bind(document);
+  //     expect($.fn.on).toHaveBeenCalled()
+  //   });
+  // });
 
-  describe('should redirect to href', function () {
-    it('should when present', function () {
-      expect(clickHandler._shouldRedirect('/')).toEqual(true);
+  // describe('should redirect to href', function () {
+  //   it('should when present', function () {
+  //     expect(clickHandler._shouldRedirect('/')).toEqual(true);
+  //   });
+
+  //   it('should not when null', function () {
+  //     expect(clickHandler._shouldRedirect(null)).toEqual(false);
+  //   });
+
+  //   it('should not when javascript:', function () {
+  //     expect(clickHandler._shouldRedirect('javascript: void(0);')).toEqual(false);
+  //   });
+  // });
+
+  // describe('#followHrefConfigured', function() {
+  //   it('should be false when not configured in any way', function() {
+  //     expect(clickHandler._followHrefConfigured(null, null, null)).toEqual(false);
+  //   });
+
+  //   it('should be true when wh followHref', function() {
+  //     expect(clickHandler._followHrefConfigured(null, null, {followHref: true})).toEqual(true);
+  //   });
+
+  //   it('should let passed options followHref override wh followHref', function() {
+  //     expect(clickHandler._followHrefConfigured(null, {followHref: true}, {followHref: false})).toEqual(true);
+  //   });
+
+  //   it('should let event options followHref override other followHref options', function() {
+  //     expect(clickHandler._followHrefConfigured({data: {followHref: true}}, {followHref: false}, {followHref: false})).toEqual(true);
+  //   });
+  // });
+
+  describe("#elemClicked", function() {
+    describe("same window link", function() {
+      beforeEach(function() {
+        setFixtures('<meta name="WH.cg" content="test"/><div id="nav_menu"><span class="icon_home sprite">Stuff</span><a class="trap" href="#to_the_past"><img class="photo" src="#"></a></div>');
+      });
+
+      describe('when not nested', function() {
+        it('does not open in new window', function() {
+          spyOn(clickHandler, '_openNewWindow');
+          spyOn(clickHandler, '_setDocumentLocation');
+          clickHandler.bind(document);
+          $(document).find('a.trap').click();
+          waitsFor(function() {
+            return clickHandler._setDocumentLocation.wasCalled;
+          });
+          runs(function() {
+            expect(clickHandler._openNewWindow).not.toHaveBeenCalled();
+          });
+        });
+      });
+
+      describe('when nested', function() {
+        it('does not open in new window', function() {
+          spyOn(clickHandler, '_openNewWindow');
+          spyOn(clickHandler, '_setDocumentLocation');
+          clickHandler.bind(document);
+          $(document).find('img.photo').click();
+          waitsFor(function() {
+            return clickHandler._setDocumentLocation.wasCalled;
+          });
+          runs(function() {
+            expect(clickHandler._openNewWindow).not.toHaveBeenCalled();
+          });
+        });
+      });
+
+      describe('when not nested', function() {
+        it('goes to clicked link', function() {
+          spyOn(clickHandler, '_setDocumentLocation');
+          clickHandler.bind(document);
+          $(document).find('a.trap').click();
+          waitsFor(function() {
+            return clickHandler._setDocumentLocation.wasCalled;
+          });
+          runs(function() {
+            expect(clickHandler._setDocumentLocation).toHaveBeenCalledWith('#to_the_past');
+          });
+        });
+      });
+
+      describe('when nested', function() {
+        it('goes to clicked link', function() {
+          spyOn(clickHandler, '_setDocumentLocation');
+          clickHandler.bind(document);
+          $(document).find('img.photo').click();
+          waitsFor(function() {
+            return clickHandler._setDocumentLocation.wasCalled;
+          });
+          runs(function() {
+            expect(clickHandler._setDocumentLocation).toHaveBeenCalledWith('#to_the_past');
+          });
+        });
+      });
     });
 
-    it('should not when null', function () {
-      expect(clickHandler._shouldRedirect(null)).toEqual(false);
-    });
+    describe("new window link (target='_blank')", function() {
+      beforeEach(function() {
+        setFixtures('<meta name="WH.cg" content="test"/><div id="nav_menu"><span class="icon_home sprite">Stuff</span><a class="trap" href="#to_the_past" target="_blank"><img class="photo" src="#"></a></div>');
+      });
 
-    it('should not when javascript:', function () {
-      expect(clickHandler._shouldRedirect('javascript: void(0);')).toEqual(false);
-    });
-  });
+      describe('when not nested', function() {
+        it('does not open in same window', function() {
+          spyOn(clickHandler, '_openNewWindow');
+          spyOn(clickHandler, '_setDocumentLocation');
+          clickHandler.bind(document);
+          $(document).find('a.trap').click();
+          waitsFor(function() {
+            return clickHandler._openNewWindow.wasCalled;
+          });
+          runs(function() {
+            expect(clickHandler._setDocumentLocation).not.toHaveBeenCalled();
+          });
+        });
+      });
 
-  describe('#followHrefConfigured', function() {
-    it('should be false when not configured in any way', function() {
-      expect(clickHandler._followHrefConfigured(null, null, null)).toEqual(false);
-    });
+      describe('when nested', function() {
+        it('does not open in same window', function() {
+          spyOn(clickHandler, '_openNewWindow');
+          spyOn(clickHandler, '_setDocumentLocation');
+          clickHandler.bind(document);
+          $(document).find('img.photo').click();
+          waitsFor(function() {
+            return clickHandler._openNewWindow.wasCalled;
+          });
+          runs(function() {
+            expect(clickHandler._setDocumentLocation).not.toHaveBeenCalled();
+          });
+        });
+      });
 
-    it('should be true when wh followHref', function() {
-      expect(clickHandler._followHrefConfigured(null, null, {followHref: true})).toEqual(true);
-    });
+      describe('when not nested', function() {
+        it('opens link in new window', function() {
+          spyOn(clickHandler, '_openNewWindow');
+          clickHandler.bind(document);
+          $(document).find('a.trap').click();
+          waitsFor(function() {
+            return clickHandler._openNewWindow.wasCalled;
+          });
+          runs(function() {
+            expect(clickHandler._openNewWindow).toHaveBeenCalledWith('#to_the_past');
+          });
+        });
+      });
 
-    it('should let passed options followHref override wh followHref', function() {
-      expect(clickHandler._followHrefConfigured(null, {followHref: true}, {followHref: false})).toEqual(true);
-    });
-
-    it('should let event options followHref override other followHref options', function() {
-      expect(clickHandler._followHrefConfigured({data: {followHref: true}}, {followHref: false}, {followHref: false})).toEqual(true);
+      describe('when nested', function() {
+        it('does not open in same window', function() {
+          spyOn(clickHandler, '_openNewWindow');
+          clickHandler.bind(document);
+          $(document).find('img.photo').click();
+          waitsFor(function() {
+            return clickHandler._openNewWindow.wasCalled;
+          });
+          runs(function() {
+            expect(clickHandler._openNewWindow).toHaveBeenCalledWith('#to_the_past');
+          });
+        });
+      });
     });
   });
 });

--- a/spec/javascripts/ClickHandlerSpec.js
+++ b/spec/javascripts/ClickHandlerSpec.js
@@ -24,4 +24,18 @@ describe('Click handler', function() {
       expect($.fn.on).toHaveBeenCalled()
     });
   });
+
+  describe('#shouldRedirectToLastLinkClicked', function () {
+    it('should when present', function () {
+      expect(clickHandler.shouldRedirect('/')).toEqual(true);
+    });
+
+    it('should not when null', function () {
+      expect(clickHandler.shouldRedirect(null)).toEqual(false);
+    });
+
+    it('should not when javascript:', function () {
+      expect(clickHandler.shouldRedirect('javascript: void(0);')).toEqual(false);
+    });
+  });
 });

--- a/spec/javascripts/ClickHandlerSpec.js
+++ b/spec/javascripts/ClickHandlerSpec.js
@@ -25,6 +25,46 @@ describe('Click handler', function() {
     });
   });
 
+  describe('#bind', function() {
+    it('should bind the event handler to an event for a selector', function() {
+      spyOn($.fn, 'on');
+      clickHandler.bind(document);
+      expect($.fn.on).toHaveBeenCalled()
+    });
+  });
+
+  describe('should redirect to href', function () {
+    it('should when present', function () {
+      expect(clickHandler._shouldRedirect('/')).toEqual(true);
+    });
+
+    it('should not when null', function () {
+      expect(clickHandler._shouldRedirect(null)).toEqual(false);
+    });
+
+    it('should not when javascript:', function () {
+      expect(clickHandler._shouldRedirect('javascript: void(0);')).toEqual(false);
+    });
+  });
+
+  describe('#followHrefConfigured', function() {
+    it('should be false when not configured in any way', function() {
+      expect(clickHandler._followHrefConfigured(null, null, null)).toEqual(false);
+    });
+
+    it('should be true when wh followHref', function() {
+      expect(clickHandler._followHrefConfigured(null, null, {followHref: true})).toEqual(true);
+    });
+
+    it('should let passed options followHref override wh followHref', function() {
+      expect(clickHandler._followHrefConfigured(null, {followHref: true}, {followHref: false})).toEqual(true);
+    });
+
+    it('should let event options followHref override other followHref options', function() {
+      expect(clickHandler._followHrefConfigured({data: {followHref: true}}, {followHref: false}, {followHref: false})).toEqual(true);
+    });
+  });
+
   describe("#elemClicked", function() {
     describe("same window link", function() {
       beforeEach(function() {

--- a/spec/javascripts/ClickHandlerSpec.js
+++ b/spec/javascripts/ClickHandlerSpec.js
@@ -1,6 +1,8 @@
-# Most of the methods in ClickHandler are tested indirectly through the WH
-# specs. Once you no longer need to support a handful of WH methods, move
-# the WH specs over to this file.
+/*
+ * Most of the methods in ClickHandler are tested indirectly through the WH
+ * specs. Once you no longer need to support a handful of WH methods, move
+ * the WH specs over to this file.
+ */
 describe('Click handler', function() {
   var clickHandler;
 
@@ -27,15 +29,33 @@ describe('Click handler', function() {
 
   describe('#shouldRedirectToLastLinkClicked', function () {
     it('should when present', function () {
-      expect(clickHandler.shouldRedirect('/')).toEqual(true);
+      expect(clickHandler._shouldRedirect('/')).toEqual(true);
     });
 
     it('should not when null', function () {
-      expect(clickHandler.shouldRedirect(null)).toEqual(false);
+      expect(clickHandler._shouldRedirect(null)).toEqual(false);
     });
 
     it('should not when javascript:', function () {
-      expect(clickHandler.shouldRedirect('javascript: void(0);')).toEqual(false);
+      expect(clickHandler._shouldRedirect('javascript: void(0);')).toEqual(false);
+    });
+  });
+
+  describe('#followHrefConfigured', function() {
+    it('should be false when not configured in any way', function() {
+      expect(clickHandler._followHrefConfigured(null, null, null)).toEqual(false);
+    });
+
+    it('should be true when wh followHref', function() {
+      expect(clickHandler._followHrefConfigured(null, null, {followHref: true})).toEqual(true);
+    });
+
+    it('should let passed options followHref override wh followHref', function() {
+      expect(clickHandler._followHrefConfigured(null, {followHref: true}, {followHref: false})).toEqual(true);
+    });
+
+    it('should let event options followHref override other followHref options', function() {
+      expect(clickHandler._followHrefConfigured({data: {followHref: true}}, {followHref: false}, {followHref: false})).toEqual(true);
     });
   });
 });

--- a/spec/javascripts/ClickHandlerSpec.js
+++ b/spec/javascripts/ClickHandlerSpec.js
@@ -27,7 +27,7 @@ describe('Click handler', function() {
     });
   });
 
-  describe('#shouldRedirectToLastLinkClicked', function () {
+  describe('should redirect to href', function () {
     it('should when present', function () {
       expect(clickHandler._shouldRedirect('/')).toEqual(true);
     });

--- a/spec/javascripts/ClickHandlerSpec.js
+++ b/spec/javascripts/ClickHandlerSpec.js
@@ -25,46 +25,6 @@ describe('Click handler', function() {
     });
   });
 
-  // describe('#bind', function() {
-  //   it('should bind the event handler to an event for a selector', function() {
-  //     spyOn($.fn, 'on');
-  //     clickHandler.bind(document);
-  //     expect($.fn.on).toHaveBeenCalled()
-  //   });
-  // });
-
-  // describe('should redirect to href', function () {
-  //   it('should when present', function () {
-  //     expect(clickHandler._shouldRedirect('/')).toEqual(true);
-  //   });
-
-  //   it('should not when null', function () {
-  //     expect(clickHandler._shouldRedirect(null)).toEqual(false);
-  //   });
-
-  //   it('should not when javascript:', function () {
-  //     expect(clickHandler._shouldRedirect('javascript: void(0);')).toEqual(false);
-  //   });
-  // });
-
-  // describe('#followHrefConfigured', function() {
-  //   it('should be false when not configured in any way', function() {
-  //     expect(clickHandler._followHrefConfigured(null, null, null)).toEqual(false);
-  //   });
-
-  //   it('should be true when wh followHref', function() {
-  //     expect(clickHandler._followHrefConfigured(null, null, {followHref: true})).toEqual(true);
-  //   });
-
-  //   it('should let passed options followHref override wh followHref', function() {
-  //     expect(clickHandler._followHrefConfigured(null, {followHref: true}, {followHref: false})).toEqual(true);
-  //   });
-
-  //   it('should let event options followHref override other followHref options', function() {
-  //     expect(clickHandler._followHrefConfigured({data: {followHref: true}}, {followHref: false}, {followHref: false})).toEqual(true);
-  //   });
-  // });
-
   describe("#elemClicked", function() {
     describe("same window link", function() {
       beforeEach(function() {

--- a/src/click_handler.coffee
+++ b/src/click_handler.coffee
@@ -29,10 +29,6 @@ define ['jquery'], ($) ->
     _openNewWindow: (href) ->
       window.open(href)
 
-    # TODO: Decouple this method from the @wh object. I don't like how we mutate
-    # the state of @wh. Creating an elemClicked method in the ClickHandler class
-    # was a good move, but we should do more work to make the separation between
-    # it and the WH class a bit cleaner.
     elemClicked: (e, options={}) =>
       domTarget = e.target
       attrs = domTarget.attributes

--- a/src/click_handler.coffee
+++ b/src/click_handler.coffee
@@ -23,6 +23,12 @@ define ['jquery'], ($) ->
       else
         if wh? then wh.followHref else false
 
+    _setDocumentLocation: (href) ->
+      document.location = href
+
+    _openNewWindow: (href) ->
+      window.open(href)
+
     # TODO: Decouple this method from the @wh object. I don't like how we mutate
     # the state of @wh. Creating an elemClicked method in the ClickHandler class
     # was a good move, but we should do more work to make the separation between
@@ -62,10 +68,10 @@ define ['jquery'], ($) ->
       if @_followHrefConfigured(e, options, @wh) && @_shouldRedirect(href)
         e.preventDefault()
         if target == "_blank"
-          window.open(href)
+          @_openNewWindow(href)
         else
-          trackingData.afterFireCallback = ->
-            document.location = href
+          trackingData.afterFireCallback = =>
+            @_setDocumentLocation(href)
 
       @wh.fire trackingData
       e.stopPropagation()

--- a/src/click_handler.coffee
+++ b/src/click_handler.coffee
@@ -57,6 +57,7 @@ define ['jquery'], ($) ->
       @wh.lastLinkClicked = href
       target = getClosestAttr('target')
       if href && followHref && @shouldRedirect(href)
+        e.preventDefault()
         if target == "_blank"
           window.open(href)
         else
@@ -64,6 +65,6 @@ define ['jquery'], ($) ->
             document.location = href
 
       @wh.fire trackingData
-      e.preventDefault()
+      e.stopPropagation()
 
   ClickHandler

--- a/src/click_handler.coffee
+++ b/src/click_handler.coffee
@@ -14,7 +14,7 @@ define ['jquery'], ($) ->
       # ignore obtrusive JS in an href attribute
       href.indexOf('javascript:') == -1
 
-    # Event and data should be as passed to the elemClicked handler
+    # Event and options should be as passed to the elemClicked handler
     _followHrefConfigured: (event, options, wh) ->
       event?.data?.followHref? || options?.followHref? || wh?.followHref?
 

--- a/src/click_handler.coffee
+++ b/src/click_handler.coffee
@@ -16,12 +16,7 @@ define ['jquery'], ($) ->
 
     # Event and data should be as passed to the elemClicked handler
     _followHrefConfigured: (event, options, wh) ->
-      if event && event.data? && event.data.followHref?
-        event.data.followHref
-      else if options? && options.followHref?
-        options.followHref
-      else
-        if wh? then wh.followHref else false
+      event?.data?.followHref? || options?.followHref? || wh?.followHref?
 
     _setDocumentLocation: (href) ->
       document.location = href

--- a/src/click_handler.coffee
+++ b/src/click_handler.coffee
@@ -58,7 +58,6 @@ define ['jquery'], ($) ->
         jQTarget.attr(attr) || jQTarget.closest('a').attr(attr)
 
       href = getClosestAttr('href')
-      @wh.lastLinkClicked = href
       target = getClosestAttr('target')
       if @_followHrefConfigured(e, options, @wh) && @_shouldRedirect(href)
         e.preventDefault()

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -40,8 +40,8 @@ define [
       @path              = "#{document.location.pathname}#{document.location.search}"
       @warehouseURL      = opts.warehouseURL
       @opts              = opts
+      @followHref = if opts.followHref? then opts.followHref else true
 
-      @setFollowHref(opts)
       @setCookies()
       @determineDocumentDimensions(document)
       @determineWindowDimensions(window)
@@ -265,11 +265,6 @@ define [
       @oneTimeData ||= {}
       for key of obj
         @oneTimeData[key] = obj[key]
-
-    # TODO: Move this to ClickHandler
-    setFollowHref: (opts={}) ->
-      @lastLinkClicked = null
-      @followHref = if opts.followHref? then opts.followHref else true
 
     replaceDoubleByteChars: (str) ->
       result = for char in str.split('')

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -162,25 +162,16 @@ define [
           .error ->
             $element.trigger('WH_pixel_error_' + obj.type)
 
-        # The request for the tracking pixel happens here.
-        @warehouseTag[0].src = requestURL
-
-        if @shouldRedirectToLastLinkClicked()
-          lastLinkRedirect = (e) =>
-            document.location = @lastLinkClicked
-
+        if obj.afterFireCallback
           @warehouseTag
             .unbind('load')
             .unbind('error')
-            .bind('load',  lastLinkRedirect)
-            .bind('error', lastLinkRedirect)
-      )
+            .bind('load',  obj.afterFireCallback)
+            .bind('error', obj.afterFireCallback)
 
-    shouldRedirectToLastLinkClicked: =>
-      @lastLinkClicked? &&
-      @lastLinkClicked.indexOf? &&
-      # ignore obtrusive JS in an href attribute
-      @lastLinkClicked.indexOf('javascript:') == -1
+        # The request for the tracking pixel happens here.
+        @warehouseTag[0].src = requestURL
+      )
 
     firedTime: =>
       now =


### PR DESCRIPTION
On AG Sites, I was doing a hack to unbind and rebind the autotag handlers because they didn't work properly on new window links.  The followHref data attribute would have never been very useful because it doesn't actually get passed unless an event is manually triggered.  To be backwards compatible, this will take the followHref option from event.data, the data passed on a manual trigger, or from the original WH init options, in that order.

I added handling to open links in a new window with a target="_blank" attribute.  This should remove the need to hack new window links.  Handling this directly in the click handler enabled this to be done when it couldn't be done previously because attempting it in a handler that wasn't called directly in response to a user event makes a window that it treated as a popup.

I would like to get more to the point that we get at least more expected behavior out of our links rather than having autotagging modifying the behavior, for example, making people wonder why the target attribute doesn't work.  This should be a step in the right direction.
