### PR TITLE
[CW] [79875314] ClickHandler#_followHrefConfigured honors false

### DIFF
--- a/click_handler.js
+++ b/click_handler.js
@@ -27,8 +27,16 @@
       };
 
       ClickHandler.prototype._followHrefConfigured = function(event, options, wh) {
-        var _ref;
-        return ((event != null ? (_ref = event.data) != null ? _ref.followHref : void 0 : void 0) != null) || ((options != null ? options.followHref : void 0) != null) || ((wh != null ? wh.followHref : void 0) != null);
+        var _ref, _ref1;
+        if ((event != null ? (_ref = event.data) != null ? _ref.followHref : void 0 : void 0) != null) {
+          return event != null ? (_ref1 = event.data) != null ? _ref1.followHref : void 0 : void 0;
+        } else if ((options != null ? options.followHref : void 0) != null) {
+          return options != null ? options.followHref : void 0;
+        } else if ((wh != null ? wh.followHref : void 0) != null) {
+          return wh != null ? wh.followHref : void 0;
+        } else {
+          return false;
+        }
       };
 
       ClickHandler.prototype._setDocumentLocation = function(href) {

--- a/spec/javascripts/ClickHandlerSpec.js
+++ b/spec/javascripts/ClickHandlerSpec.js
@@ -52,8 +52,20 @@ describe('Click handler', function() {
       expect(clickHandler._followHrefConfigured(null, null, null)).toEqual(false);
     });
 
+    it('should be false when event sets followHref to false', function() {
+      expect(clickHandler._followHrefConfigured({ data: { followHref: false } }, null, null)).toEqual(false);
+    });
+
     it('should be true when wh followHref', function() {
       expect(clickHandler._followHrefConfigured(null, null, {followHref: true})).toEqual(true);
+    });
+
+    it('should be false when wh sets followHref to false', function() {
+      expect(clickHandler._followHrefConfigured(null, null, {followHref: true})).toEqual(true);
+    });
+
+    it('should be false when options sets followHref to false', function() {
+      expect(clickHandler._followHrefConfigured(null, null, {followHref: false})).toEqual(false);
     });
 
     it('should let passed options followHref override wh followHref', function() {

--- a/src/click_handler.coffee
+++ b/src/click_handler.coffee
@@ -16,7 +16,14 @@ define ['jquery'], ($) ->
 
     # Event and options should be as passed to the elemClicked handler
     _followHrefConfigured: (event, options, wh) ->
-      event?.data?.followHref? || options?.followHref? || wh?.followHref?
+      if event?.data?.followHref?
+        event?.data?.followHref
+      else if options?.followHref?
+        options?.followHref
+      else if wh?.followHref?
+        wh?.followHref
+      else
+        false
 
     _setDocumentLocation: (href) ->
       document.location = href


### PR DESCRIPTION
- `ClickHandler#_followHrefConfigurued` previously checked if it was set and did not return the actual value.
- Now it checks if a value is set and returns it.
- Added specs to include false values.

[Story](https://www.pivotaltracker.com/story/show/79875314)
