### PR TITLE
[CW] [81968454] Remove need for warehouse tag to trigger a load event.

### DIFF
--- a/dist/non-amd/jquery.autotagging.js
+++ b/dist/non-amd/jquery.autotagging.js
@@ -200,7 +200,7 @@ jquery_autotagging_click_handler = function ($) {
       return window.open(href);
     };
     ClickHandler.prototype.elemClicked = function (e, options) {
-      var attr, attrs, domTarget, getClosestAttr, href, item, jQTarget, realName, subGroup, target, trackingData, value, _i, _len, _ref;
+      var attr, attrs, domTarget, getClosestAttr, item, jQTarget, realName, subGroup, trackingData, value, _i, _len, _ref;
       if (options == null) {
         options = {};
       }
@@ -231,22 +231,7 @@ jquery_autotagging_click_handler = function ($) {
       getClosestAttr = function (attr) {
         return jQTarget.attr(attr) || jQTarget.closest('a').attr(attr);
       };
-      href = getClosestAttr('href');
-      target = getClosestAttr('target');
-      if (this._followHrefConfigured(e, options, this.wh) && this._shouldRedirect(href)) {
-        e.preventDefault();
-        if (target === '_blank' || e.ctrlKey || e.metaKey) {
-          this._openNewWindow(href);
-        } else {
-          trackingData.afterFireCallback = function (_this) {
-            return function () {
-              return _this._setDocumentLocation(href);
-            };
-          }(this);
-        }
-      }
-      this.wh.fire(trackingData);
-      return e.stopPropagation();
+      return this.wh.fire(trackingData);
     };
     return ClickHandler;
   }();
@@ -330,6 +315,7 @@ jquery_autotagging_select_change_handler = function ($) {
  */
 (function (factory) {
   if (true) {
+    // AMD. Register as anonymous module.
     jquerycookie = function (jQuery) {
       return typeof factory === 'function' ? factory(jQuery) : factory;
     }(jQuery);
@@ -599,30 +585,14 @@ jquery_autotagging_jqueryautotagging = function ($, browserdetect, ClickEventHan
       }
       return this.obj2query($.extend(obj, this.metaData), function (_this) {
         return function (query) {
-          var requestURL;
+          var requestURL, warehouseTag;
           requestURL = _this.warehouseURL + query;
           if (requestURL.length > 2048 && navigator.userAgent.indexOf('MSIE') >= 0) {
             requestURL = requestURL.substring(0, 2043) + '&tu=1';
           }
-          if (!_this.warehouseTag) {
-            _this.warehouseTag = $('<img/>', {
-              id: 'PRMWarehouseTag',
-              border: '0',
-              width: '1',
-              height: '1'
-            });
-          }
-          $element = $element || $('body');
-          _this.warehouseTag.unbind('load').load(function () {
-            return $element.trigger('WH_pixel_success_' + obj.type);
-          });
-          _this.warehouseTag.unbind('error').error(function () {
-            return $element.trigger('WH_pixel_error_' + obj.type);
-          });
-          if (obj.afterFireCallback) {
-            _this.warehouseTag.unbind('load').unbind('error').bind('load', obj.afterFireCallback).bind('error', obj.afterFireCallback);
-          }
-          return _this.warehouseTag[0].src = requestURL;
+          warehouseTag = new Image();
+          warehouseTag.src = requestURL;
+          return typeof obj.afterFireCallback === 'function' ? obj.afterFireCallback() : void 0;
         };
       }(this));
     };

--- a/dist/shared/click_handler.js
+++ b/dist/shared/click_handler.js
@@ -47,7 +47,7 @@ define(['jquery'], function($) {
     };
 
     ClickHandler.prototype.elemClicked = function(e, options) {
-      var attr, attrs, domTarget, getClosestAttr, href, item, jQTarget, realName, subGroup, target, trackingData, value, _i, _len, _ref;
+      var attr, attrs, domTarget, item, jQTarget, realName, subGroup, trackingData, value, _i, _len, _ref;
       if (options == null) {
         options = {};
       }
@@ -75,25 +75,7 @@ define(['jquery'], function($) {
           trackingData[realName] = attr.value;
         }
       }
-      getClosestAttr = function(attr) {
-        return jQTarget.attr(attr) || jQTarget.closest('a').attr(attr);
-      };
-      href = getClosestAttr('href');
-      target = getClosestAttr('target');
-      if (this._followHrefConfigured(e, options, this.wh) && this._shouldRedirect(href)) {
-        e.preventDefault();
-        if ((target === "_blank") || e.ctrlKey || e.metaKey) {
-          this._openNewWindow(href);
-        } else {
-          trackingData.afterFireCallback = (function(_this) {
-            return function() {
-              return _this._setDocumentLocation(href);
-            };
-          })(this);
-        }
-      }
-      this.wh.fire(trackingData);
-      return e.stopPropagation();
+      return this.wh.fire(trackingData);
     };
 
     return ClickHandler;

--- a/dist/shared/jquery.autotagging.js
+++ b/dist/shared/jquery.autotagging.js
@@ -207,30 +207,14 @@ define(['jquery', 'browserdetect', './click_handler', './select_change_handler',
       }
       return this.obj2query($.extend(obj, this.metaData), (function(_this) {
         return function(query) {
-          var requestURL;
+          var requestURL, warehouseTag;
           requestURL = _this.warehouseURL + query;
           if (requestURL.length > 2048 && navigator.userAgent.indexOf('MSIE') >= 0) {
             requestURL = requestURL.substring(0, 2043) + "&tu=1";
           }
-          if (!_this.warehouseTag) {
-            _this.warehouseTag = $('<img/>', {
-              id: 'PRMWarehouseTag',
-              border: '0',
-              width: '1',
-              height: '1'
-            });
-          }
-          $element = $element || $('body');
-          _this.warehouseTag.unbind('load').load(function() {
-            return $element.trigger('WH_pixel_success_' + obj.type);
-          });
-          _this.warehouseTag.unbind('error').error(function() {
-            return $element.trigger('WH_pixel_error_' + obj.type);
-          });
-          if (obj.afterFireCallback) {
-            _this.warehouseTag.unbind('load').unbind('error').bind('load', obj.afterFireCallback).bind('error', obj.afterFireCallback);
-          }
-          return _this.warehouseTag[0].src = requestURL;
+          warehouseTag = new Image;
+          warehouseTag.src = requestURL;
+          return typeof obj.afterFireCallback === "function" ? obj.afterFireCallback() : void 0;
         };
       })(this));
     };

--- a/src/click_handler.coffee
+++ b/src/click_handler.coffee
@@ -61,20 +61,6 @@ define [
           realName = attr.name.replace('data-', '')
           trackingData[realName] = attr.value
 
-      getClosestAttr = (attr) ->
-        jQTarget.attr(attr) || jQTarget.closest('a').attr(attr)
-
-      href = getClosestAttr('href')
-      target = getClosestAttr('target')
-      if @_followHrefConfigured(e, options, @wh) && @_shouldRedirect(href)
-        e.preventDefault()
-        if (target == "_blank") || e.ctrlKey || e.metaKey
-          @_openNewWindow(href)
-        else
-          trackingData.afterFireCallback = =>
-            @_setDocumentLocation(href)
-
       @wh.fire trackingData
-      e.stopPropagation()
 
   ClickHandler

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -144,32 +144,10 @@ define [
         if requestURL.length > 2048 and navigator.userAgent.indexOf('MSIE') >= 0
           requestURL = requestURL.substring(0,2043) + "&tu=1"
 
-        unless @warehouseTag
-          @warehouseTag = $('<img/>',
-            {id:'PRMWarehouseTag', border:'0', width:'1', height:'1'})
+        warehouseTag = new Image
+        warehouseTag.src = requestURL
 
-        $element = $element || $('body')
-
-        # NOTE: Binding to 'load' has several caveats: http://api.jquery.com/load-event/
-        @warehouseTag
-          .unbind('load')
-          .load ->
-            $element.trigger('WH_pixel_success_' + obj.type)
-
-        @warehouseTag
-          .unbind('error')
-          .error ->
-            $element.trigger('WH_pixel_error_' + obj.type)
-
-        if obj.afterFireCallback
-          @warehouseTag
-            .unbind('load')
-            .unbind('error')
-            .bind('load',  obj.afterFireCallback)
-            .bind('error', obj.afterFireCallback)
-
-        # The request for the tracking pixel happens here.
-        @warehouseTag[0].src = requestURL
+        obj.afterFireCallback?()
       )
 
     firedTime: =>


### PR DESCRIPTION
**This is an exploratory PR to find what effects these changes have. Please provide feedback but HOLD OFF MERGING**
- Reduces page loads by at least 100ms.
- Removes round trip time. Tag fires and page goes to the next without waiting.
- No need to attach the `<img>` to the DOM. Just the src and the browser fires it without jQuery.
- Remove `event.preventDefault()`. This makes it less intrusive, but is a breaking change in that apps may rely on this (e.g. the AG SRP actions).
- Remove `event.stopPropagation()`. This also makes it less intrustive, but is a breaking change since apps may rely on it (e.g. AG fires two tags when saving a property).

Note: The browser may show that the image tag request was cancelled, but checking Charles (Mac and IE 8), shows that it was sent.

[Story](https://www.pivotaltracker.com/story/show/81968454)

/cc @Ebtoulson 
