### PR TITLE
[CW] [81968454] Add <img> to DOM. Bump to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# v2.1.0
+* [breaking change] Remove calls to event.stopPropagation() and
+  event.preventDefault(). [#26]
+* [feature] Callbacks no longer waiting until the tag is loaded. Reduces
+  page load times by at least 100ms. [#26]
+* [feature] Fire multiple tags at once. Internally it no longer re-uses
+  the same <img> element. [#26]
+
+[Compare v2.0.4..v2.1.0](https://github.com/primedia/jquery-autotagging/compare/v2.0.4...v2.1.0)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-autotagging",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "main": "dist/shared/jquery.autotagging.js",
   "dependencies": {
     "jquery": ">=1.8.3 <2.0.0",

--- a/dist/non-amd/jquery.autotagging.js
+++ b/dist/non-amd/jquery.autotagging.js
@@ -200,7 +200,7 @@ jquery_autotagging_click_handler = function ($) {
       return window.open(href);
     };
     ClickHandler.prototype.elemClicked = function (e, options) {
-      var attr, attrs, domTarget, getClosestAttr, item, jQTarget, realName, subGroup, trackingData, value, _i, _len, _ref;
+      var attr, attrs, domTarget, item, jQTarget, realName, subGroup, trackingData, value, _i, _len, _ref;
       if (options == null) {
         options = {};
       }
@@ -228,9 +228,6 @@ jquery_autotagging_click_handler = function ($) {
           trackingData[realName] = attr.value;
         }
       }
-      getClosestAttr = function (attr) {
-        return jQTarget.attr(attr) || jQTarget.closest('a').attr(attr);
-      };
       return this.wh.fire(trackingData);
     };
     return ClickHandler;

--- a/dist/shared/jquery.autotagging.js
+++ b/dist/shared/jquery.autotagging.js
@@ -212,8 +212,9 @@ define(['jquery', 'browserdetect', './click_handler', './select_change_handler',
           if (requestURL.length > 2048 && navigator.userAgent.indexOf('MSIE') >= 0) {
             requestURL = requestURL.substring(0, 2043) + "&tu=1";
           }
-          warehouseTag = new Image;
-          warehouseTag.src = requestURL;
+          warehouseTag = document.createElement("img");
+          warehouseTag.setAttribute("src", requestURL);
+          document.body.appendChild(warehouseTag);
           return typeof obj.afterFireCallback === "function" ? obj.afterFireCallback() : void 0;
         };
       })(this));

--- a/src/jquery.autotagging.coffee
+++ b/src/jquery.autotagging.coffee
@@ -144,8 +144,9 @@ define [
         if requestURL.length > 2048 and navigator.userAgent.indexOf('MSIE') >= 0
           requestURL = requestURL.substring(0,2043) + "&tu=1"
 
-        warehouseTag = new Image
-        warehouseTag.src = requestURL
+        warehouseTag = document.createElement "img"
+        warehouseTag.setAttribute "src", requestURL
+        document.body.appendChild warehouseTag
 
         obj.afterFireCallback?()
       )


### PR DESCRIPTION
- Add the `<img>` to the DOM to prevent aborted requests (ref:
  http://blog.catchpoint.com/2010/08/24/counting-discrepancies-a-cancer/)
- Introduce CHANGELOG
- Bump to 2.1.0

[Story](https://www.pivotaltracker.com/story/show/81968454)
