### PR TITLE
[DR] [00000] Upgrade jQuery jquery-cookie and browser-detect

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "jquery-autotagging",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "dist/shared/jquery.autotagging.js",
   "dependencies": {
-    "jquery": ">=1.8.3 <2.0.0",
-    "jquery.cookie": "git@github.com:js-cookie/js-cookie#1.4.0",
-    "browser-detect": "git@github.com:rentpath/browser-detect.js.git#1.2.0",
+    "jquery": ">=1.8.3",
+    "jquery.cookie": "git@github.com:js-cookie/js-cookie#2.1.1",
+    "browser-detect": "git@github.com:rentpath/browser-detect.js.git#2.0.0",
     "requirejs": "*"
   },
   "ignore": [
@@ -25,6 +25,6 @@
     "guplfile.coffee"
   ],
   "resolutions": {
-    "jquery": ">=1.8.3 <2.0.0"
+    "jquery": ">=1.8.3"
   }
 }


### PR DESCRIPTION
Updating jquery due to version conflicts between libs.
Updating jquery-cookie and browser-detect to latest versions.
